### PR TITLE
Fix MultiIndex handling from yfinance

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,6 +39,10 @@ def analyze_asset(symbol):
     try:
         df = yf.download(tickers=symbol, period="7d", interval="15m", progress=False)
 
+        # Handle MultiIndex columns that yfinance may return
+        if isinstance(df.columns, pd.MultiIndex):
+            df.columns = df.columns.get_level_values(-1)
+
         if df is None or df.empty or len(df) < 60:
             return None
 


### PR DESCRIPTION
## Summary
- handle MultiIndex columns returned by `yfinance.download` to avoid shape errors

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_685a532ec7b08320a31fab2f1f7e738c