### PR TITLE
Fix 'Close' column KeyError

### DIFF
--- a/main.py
+++ b/main.py
@@ -53,9 +53,15 @@ def analyze_asset(symbol):
 
         # Normalizza i nomi delle colonne e gestisce la possibile presenza di
         # "Adj Close" al posto di "Close" nelle versioni recenti di yfinance.
-        df.columns = [c.title() for c in df.columns]
+        df.columns = [str(c).strip().title() for c in df.columns]
         if "Adj Close" in df.columns and "Close" not in df.columns:
             df.rename(columns={"Adj Close": "Close"}, inplace=True)
+
+        # Alcuni rari casi restituiscono un DataFrame senza colonna "Close".
+        # Meglio interrompere l'analisi per evitare eccezioni nelle
+        # librerie di indicatori tecnici.
+        if "Close" not in df.columns:
+            raise KeyError("Close non trovato nei dati")
 
         if df is None or df.empty or len(df) < 60:
             return None


### PR DESCRIPTION
## Summary
- handle cases where yfinance returns a dataframe without `Close`

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685a5cbc1be483208437b97122a0a434