### PR TITLE
Remove mini-analysis messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@
 - Usa 5 USDT per ogni trade spot
 - Riceverai notifiche su Telegram
 - All'avvio il bot invia un messaggio di prova su Telegram
-- In questa versione di test invia una mini-analisi (o un messaggio di errore) per ogni asset ad ogni scansione
+- In questa versione di test invia solo i segnali (o un messaggio di errore) per ogni asset ad ogni scansione
 - Se i dati non contengono la colonna "Close" viene indicata nel log la lista delle colonne trovate

--- a/main.py
+++ b/main.py
@@ -158,15 +158,7 @@ Strategia: {sig['strategy']}"""
             log(msg.replace("\n", " | "))
             notify_telegram(msg)
 
-        mini_msg = (
-            f"📊 Mini-analisi {result['symbol']}\n"
-            f"Prezzo: {result['price']}\n"
-            f"RSI: {result['rsi']}\n"
-            f"SMA20: {result['sma20']}\n"
-            f"SMA50: {result['sma50']}"
-        )
-        log(mini_msg.replace("\n", " | "))
-        notify_telegram(mini_msg)
+        # Le mini-analisi sono state rimosse: il bot ora invia solo i segnali
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove mini-analysis logs and Telegram notifications
- mention only signal alerts in the README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_685ab89982f08320b6f1f7ede921c6d7