### PR TITLE
Add automatic trading via Bybit API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ BYBIT_API_KEY=your_bybit_api_key
 BYBIT_API_SECRET=your_bybit_api_secret
 TELEGRAM_TOKEN=your_telegram_token
 TELEGRAM_CHAT_ID=your_telegram_chat_id
+BYBIT_TESTNET=true
+ORDER_USDT=5

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 ## ⚠️ Attenzione
 - Il bot è attivo 24/7
-- Usa 5 USDT per ogni trade spot
+- Usa 5 USDT per ogni trade spot (modificabile con `ORDER_USDT`)
 - Riceverai notifiche su Telegram
 - All'avvio il bot invia un messaggio di prova su Telegram
-- In questa versione di test invia solo i segnali (o un messaggio di errore) per ogni asset ad ogni scansione
+- In questa versione il bot può inviare ordini automatici su Bybit se imposti le chiavi API
 - Se i dati non contengono la colonna "Close" viene indicata nel log la lista delle colonne trovate
 
-## Aggiornamento di test
-Questo commit serve solo per verificare il bypass del ruleset.
+## Aggiornamento
+Il bot ora supporta l'invio di ordini automatici su Bybit utilizzando le chiavi API presenti nel file `.env`.


### PR DESCRIPTION
## Summary
- add Bybit API config and helper to send orders
- place orders whenever a trading signal is detected
- document new environment variables
- mention new feature in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_685ac01a14b08320b7aa47ae0152246f