### PR TITLE
Remove deprecated alias function

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@
 - Se non usi l'account unificato imposta `BYBIT_ACCOUNT_TYPE=SPOT` nel file `.env`
 - All'avvio il bot invia un messaggio di prova su Telegram e verifica la
   connessione a Bybit; **non** viene eseguito alcun ordine di test
-- Per compatibilità con versioni precedenti, la funzione `initial_buy_test()`
-  è ora solo un alias di `test_bybit_connection()`
 - In questa versione il bot può inviare ordini automatici su Bybit se imposti le chiavi API
 - Se i dati non contengono la colonna "Close" viene indicata nel log la lista delle colonne trovate
 - Se il download dei dati fallisce per problemi di rete, il bot effettua alcuni tentativi automatici

--- a/main.py
+++ b/main.py
@@ -353,10 +353,6 @@ def test_bybit_connection() -> None:
         log(msg)
         notify_telegram(msg)
 
-def initial_buy_test() -> None:
-    """Alias mantenuto per retrocompatibilità."""
-    test_bybit_connection()
-
 def find_close_column(df: pd.DataFrame) -> Optional[str]:
     """Trova il nome della colonna di chiusura, se esiste."""
     cols = [str(c).strip().lower().replace(" ", "_") for c in df.columns]
@@ -517,7 +513,6 @@ if __name__ == "__main__":
     # Esegui solo un test di connessione alle API, senza alcun ordine di prova
     test_bybit_connection()
     notify_telegram("🔔 Test: bot avviato correttamente")
-    initial_buy_test()
     while True:
         try:
             scan_assets()


### PR DESCRIPTION
## Summary
- drop `initial_buy_test` alias from main script
- remove its invocation on startup
- update docs: remove note about the old alias

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68629641ab788320a650d7f0d2358d8c